### PR TITLE
Handle more SDL events

### DIFF
--- a/src/yds_sdl_window_system.cpp
+++ b/src/yds_sdl_window_system.cpp
@@ -58,6 +58,7 @@ void ysSdlWindowSystem::SurveyMonitors() {
 
 void ysSdlWindowSystem::ProcessMessages() {
     auto *inputSystem = static_cast<ysSdlInputSystem *>(GetInputSystem());
+    auto *window = ysWindowSystem::GetWindow(0);
 
     // Grab all the queued events
     SDL_Event event;
@@ -65,6 +66,14 @@ void ysSdlWindowSystem::ProcessMessages() {
         switch (event.type) {
             case SDL_QUIT:
                 // TODO: quit
+                break;
+
+            // Window events
+            case SDL_WINDOWEVENT:
+                switch (event.window.event) {
+                    default:
+                        break;
+                }
                 break;
 
             // Input events

--- a/src/yds_sdl_window_system.cpp
+++ b/src/yds_sdl_window_system.cpp
@@ -65,7 +65,7 @@ void ysSdlWindowSystem::ProcessMessages() {
     while (SDL_PollEvent(&event)) {
         switch (event.type) {
             case SDL_QUIT:
-                // TODO: quit
+                ysWindowSystem::Get()->CloseWindow(window);
                 break;
 
             // Window events

--- a/src/yds_sdl_window_system.cpp
+++ b/src/yds_sdl_window_system.cpp
@@ -71,6 +71,9 @@ void ysSdlWindowSystem::ProcessMessages() {
             // Window events
             case SDL_WINDOWEVENT:
                 switch (event.window.event) {
+                    case SDL_WINDOWEVENT_SIZE_CHANGED:
+                        window->SetWindowSize(event.window.data1, event.window.data2);
+                        break;
                     default:
                         break;
                 }


### PR DESCRIPTION
This adds basic support for SDL resizing events as well as handling SDL_QUIT.

One thing I'm slightly unsure about is that I use `GetWindow(0)`. Is there a case where `0` is the incorrect value? (and if so how would you get the correct value?).

Other thing being not too sure if that's the correct way to shut down the program, but it seems to work fine from testing.